### PR TITLE
Hline height changed to min-height

### DIFF
--- a/active_statistics/static/styles.css
+++ b/active_statistics/static/styles.css
@@ -409,7 +409,7 @@ body {
 }
 
 .hline {
-    height: 2px;
+    min-height: 2px;
     align-self: stretch;
 
     border-radius: 1px;


### PR DESCRIPTION
Previously when the tabs overflowed, it was get squashed to 0px height before scrolling began.