### PR TITLE
Hovertext on cumulative time chart fixed.

### DIFF
--- a/active_statistics/statistics/plots/cumulative_time_spent.py
+++ b/active_statistics/statistics/plots/cumulative_time_spent.py
@@ -99,7 +99,7 @@ def plot_graph(
                 for i in range(len(year_data))
             ),
             hovertemplate="<b>Date: %{customdata|%d %b %Y}</b><br>"
-            + "<b>Kilometers</b>: %{y:.0f}<br>",
+            + "<b>Hours</b>: %{y:.0f}<br>",
         )
 
     return dd


### PR DESCRIPTION
The hovertext on the cumulative time chart should be hours (since it's time) and not kilometers.