### PR TITLE
Fix issue in pace timeline with no moving time

### DIFF
--- a/active_statistics/statistics/plots/pace_timeline.py
+++ b/active_statistics/statistics/plots/pace_timeline.py
@@ -15,9 +15,7 @@ from stravalib import unithelper as uh
 from stravalib.model import Activity, ActivityType
 
 from active_statistics.exceptions import UserVisibleException
-from active_statistics.statistics.utils.average_speed_utils import (
-    get_y_axis_settings,
-)
+from active_statistics.statistics.utils.average_speed_utils import get_y_axis_settings
 
 
 @dataclasses.dataclass
@@ -210,7 +208,11 @@ def generate_weighted_moving_average(
     final_dates: list[dt.datetime] = []
     final_values: list[float] = []
     for date, value in zip(dates, values):
-        if math.isnan(value) and math.isnan(final_values[-1]):
+        if (
+            len(final_values) != 0
+            and math.isnan(value)
+            and math.isnan(final_values[-1])
+        ):
             continue
         else:
             final_dates.append(date)

--- a/tests/test_visualisations/test_pace_timeline.py
+++ b/tests/test_visualisations/test_pace_timeline.py
@@ -1,7 +1,11 @@
+import datetime as dt
+
 import pytest
+from stravalib.unithelper import Quantity
 
 from active_statistics.exceptions import UserVisibleException
 from active_statistics.statistics.plots.pace_timeline import plot
+from tests.factories.activity_factories import ActivityFactory
 
 
 def test_pace_timeline(some_basic_runs_and_rides) -> None:
@@ -11,3 +15,20 @@ def test_pace_timeline(some_basic_runs_and_rides) -> None:
 def test_no_data(no_activities_at_all) -> None:
     with pytest.raises(UserVisibleException):
         plot(no_activities_at_all)
+
+
+def test_first_activities_have_no_average_speeds() -> None:
+    activities = [
+        ActivityFactory(
+            type="Run",
+            start_date_local=dt.datetime(2015, 1, 1, 6),
+            average_speed=Quantity(0.0, "m/s"),
+            moving_time=0,
+        ),
+        ActivityFactory(
+            type="Run",
+            start_date_local=dt.datetime(2020, 1, 1, 6),
+            average_speed=Quantity(10, "m/s"),
+        ),
+    ]
+    plot(_ for _ in activities)


### PR DESCRIPTION
Sometimes the "moving time" of an activity is broken in Strava. Typically for very old Garmin uploads, this field is either zero or way too large. If it is zero, when we resample to create the moving average lines, we can divide by zero, and get extra NaN's and then filter them out. Very niche issue, but this takes care of it + adds a test to make sure we don't regress.