### PR TITLE
Fix Average Heartrate Tickvals Issue

### DIFF
--- a/active_statistics/statistics/plots/average_heartrate_by_average_speed.py
+++ b/active_statistics/statistics/plots/average_heartrate_by_average_speed.py
@@ -146,7 +146,8 @@ def get_scatter_plot(
         for i in range(
             min(start_timestamps),
             max(start_timestamps),
-            (max(start_timestamps) - min(start_timestamps)) // 5,
+            # The outter max is stopping this from going below 1, which can happen in cases of very few activities.
+            max(1, (max(start_timestamps) - min(start_timestamps)) // 5),
         )
     ]
     ticktext = [dt.datetime.fromtimestamp(i).strftime("%d/%m/%Y") for i in tickvals]

--- a/tests/test_visualisations/test_average_heartrate_by_average_speed.py
+++ b/tests/test_visualisations/test_average_heartrate_by_average_speed.py
@@ -2,14 +2,18 @@ import pytest
 
 from active_statistics.exceptions import UserVisibleException
 from active_statistics.statistics.plots.average_heartrate_by_average_speed import plot
+from tests.factories.activity_factories import ActivityFactory
 
 
-def test_average_heartrate_by_average_speed_animation(
-    some_basic_runs_and_rides,
-) -> None:
+def test_average_heartrate_by_average_speed_plot(some_basic_runs_and_rides) -> None:
     plot(some_basic_runs_and_rides)
 
 
 def test_no_data(no_activities_at_all) -> None:
     with pytest.raises(UserVisibleException):
         plot(no_activities_at_all)
+
+
+def test_average_heartrate_by_average_speed_few_activities() -> None:
+    activities = [ActivityFactory(), ActivityFactory()]
+    plot(_ for _ in activities)


### PR DESCRIPTION
If there are very few activities of a certain type, then range's third arg would be zero, which doesn't make sense and errors. This stops that from happening by wrapping it in max(1, X), so the value is never below 1.