### PR TITLE
Improve sidebar

### DIFF
--- a/frontend/app/home/layout.tsx
+++ b/frontend/app/home/layout.tsx
@@ -189,7 +189,7 @@ export default function HomeLayout({ children }: { children: React.ReactNode }) 
           setDetailedDataStatus,
         }}
       >
-        <TopBar burgerMenuFunction={toggleSidebar} />
+        <TopBar sidebarVisible={sidebarVisible} toggleSidebar={toggleSidebar} />
         <div className="flex flex-row p-2 gap-2 grow overflow-auto">
           <SideBar
             sidebarVisible={sidebarVisible}

--- a/frontend/app/home/layout.tsx
+++ b/frontend/app/home/layout.tsx
@@ -67,7 +67,7 @@ export default function HomeLayout({ children }: { children: React.ReactNode }) 
 
   function pollDataStatus(
     type: "detailed" | "summary",
-    callback?: (status: any) => void,
+    callback?: (status: any) => void
   ) {
     // If polling has finished, the callback is called.
     if (type == "detailed") {
@@ -103,7 +103,7 @@ export default function HomeLayout({ children }: { children: React.ReactNode }) 
   function updateDisabledSidebarSteps(
     type: "summary" | "detailed",
     status: string,
-    setDisabledSidebarSteps: (updater: (prevSteps: string[]) => string[]) => void,
+    setDisabledSidebarSteps: (updater: (prevSteps: string[]) => string[]) => void
   ) {
     const sidebarKey = type === "summary" ? "summary_data" : "detailed_data";
 
@@ -129,7 +129,7 @@ export default function HomeLayout({ children }: { children: React.ReactNode }) 
       })
       .catch((err) => {
         console.log(
-          "Oopsie, an error happened while fetching whether or not the user is paid.",
+          "Oopsie, an error happened while fetching whether or not the user is paid."
         );
       });
   }
@@ -193,6 +193,7 @@ export default function HomeLayout({ children }: { children: React.ReactNode }) 
         <div className="flex flex-row p-2 gap-2 grow overflow-auto">
           <SideBar
             sidebarVisible={sidebarVisible}
+            toggleSidebar={toggleSidebar}
             disabledSidebarSteps={disabledSidebarSteps}
           />
           {/* Content */}

--- a/frontend/components/burger_menu/burger_menu_button.tsx
+++ b/frontend/components/burger_menu/burger_menu_button.tsx
@@ -1,25 +1,17 @@
-"use client";
-
-import { useState } from "react";
 import styles from "./burger_menu_button.module.css";
 
 interface BurgerMenuIconProps {
-  onButtonClick: () => void;
+  isBurgerIcon: boolean;
+  toggleIcon: () => void;
 }
 
 export default function BurgerMenuIcon(props: BurgerMenuIconProps) {
-  const [isActive, setIsActive] = useState(false);
-
-  const menuBtnFunction = () => {
-    setIsActive(!isActive);
-    props.onButtonClick();
-  };
-  const buttonClasses = isActive
-    ? `${styles.burger_menu_button} ${styles.active}`
-    : styles.burger_menu_button;
+  const buttonClasses = props.isBurgerIcon
+    ? styles.burger_menu_button
+    : `${styles.burger_menu_button} ${styles.active}`;
 
   return (
-    <div className={buttonClasses} onClick={menuBtnFunction}>
+    <div className={buttonClasses} onClick={props.toggleIcon}>
       <span></span>
     </div>
   );

--- a/frontend/components/side_bar/side_bar.module.css
+++ b/frontend/components/side_bar/side_bar.module.css
@@ -2,5 +2,10 @@
 /* I can't for the life of me figure out how to do this in regular tailwind. */
 
 .custom_sidebar {
-  height: calc(100vh - 5rem);
+  height: calc(100% - 5rem);
+}
+
+.custom_behind_sidebar {
+  height: calc(100% - 5rem);
+  width: calc(100% - 2rem);
 }

--- a/frontend/components/side_bar/side_bar.tsx
+++ b/frontend/components/side_bar/side_bar.tsx
@@ -9,6 +9,7 @@ import { usePathname } from "next/navigation";
 
 interface SideBarProps {
   sidebarVisible: boolean;
+  toggleSidebar: () => void;
   disabledSidebarSteps: string[];
 }
 
@@ -16,7 +17,9 @@ export default function SideBar(props: SideBarProps) {
   return (
     <div
       className={`w-72 h-full overflow-auto shrink-0 p-2 rounded-lg bg-green-500 ${
-        props.sidebarVisible ? `absolute z-40 ${styles.custom_sidebar}` : "hidden"
+        props.sidebarVisible
+          ? `absolute z-40 ${styles.custom_sidebar} lg:static`
+          : "hidden"
       } lg:block`}
     >
       <SideBarButtons disabledSidebarSteps={props.disabledSidebarSteps} />

--- a/frontend/components/side_bar/side_bar.tsx
+++ b/frontend/components/side_bar/side_bar.tsx
@@ -19,7 +19,7 @@ export default function SideBar(props: SideBarProps) {
       {/* This magic div is secretly behind the sidebar when it's open (when
         the screen is small) and closes the bar when people click on it. */}
       <div
-        className={`overflow-auto shrink-0 p-2 z-30 opacity-50 bg-slate-500 ${
+        className={`overflow-auto shrink-0 p-2 z-30 opacity-100 ${
           props.sidebarVisible
             ? `absolute z-40 ${styles.custom_behind_sidebar} lg:static`
             : "hidden"
@@ -30,8 +30,8 @@ export default function SideBar(props: SideBarProps) {
       <div
         className={`w-72 h-full overflow-auto shrink-0 p-2 rounded-lg bg-green-500 ${
           props.sidebarVisible
-            ? `absolute z-40 ${styles.custom_sidebar} lg:static`
-            : "hidden"
+            ? `absolute z-40 ${styles.custom_sidebar} lg:static transition-all`
+            : `absolute z-40 ${styles.custom_sidebar} translate-x-[-300px] transition-all`
         } lg:block`}
       >
         <SideBarButtons disabledSidebarSteps={props.disabledSidebarSteps} />
@@ -39,28 +39,6 @@ export default function SideBar(props: SideBarProps) {
     </>
   );
 }
-
-// export default function SideBar(props: SideBarProps) {
-//   return (
-//     <>
-//       {/* <div
-//         className={`h-full w-full left-0 bg-gray-500 z-30 opacity-40 ${
-//           props.sidebarVisible ? "absolute" : "hidden"
-//         }`}
-//         onClick={props.toggleSidebar}
-//       ></div> */}
-//       <div
-//         className={`w-72 h-full overflow-auto shrink-0 p-2 rounded-lg bg-green-500 ${
-//           props.sidebarVisible
-//             ? `absolute z-40 ${styles.custom_sidebar} transition-all`
-//             : `translate-x-[-300px] transition-all`
-//         } lg:block`}
-//       >
-//         <SideBarButtons disabledSidebarSteps={props.disabledSidebarSteps} />
-//       </div>
-//     </>
-//   );
-// }
 
 interface SidebarButtonsProps {
   disabledSidebarSteps: string[];

--- a/frontend/components/side_bar/side_bar.tsx
+++ b/frontend/components/side_bar/side_bar.tsx
@@ -15,17 +15,52 @@ interface SideBarProps {
 
 export default function SideBar(props: SideBarProps) {
   return (
-    <div
-      className={`w-72 h-full overflow-auto shrink-0 p-2 rounded-lg bg-green-500 ${
-        props.sidebarVisible
-          ? `absolute z-40 ${styles.custom_sidebar} lg:static`
-          : "hidden"
-      } lg:block`}
-    >
-      <SideBarButtons disabledSidebarSteps={props.disabledSidebarSteps} />
-    </div>
+    <>
+      {/* This magic div is secretly behind the sidebar when it's open (when
+        the screen is small) and closes the bar when people click on it. */}
+      <div
+        className={`overflow-auto shrink-0 p-2 z-30 opacity-50 bg-slate-500 ${
+          props.sidebarVisible
+            ? `absolute z-40 ${styles.custom_behind_sidebar} lg:static`
+            : "hidden"
+        } lg:hidden`}
+        onClick={props.toggleSidebar}
+      ></div>
+      {/* This is the actual sidebar */}
+      <div
+        className={`w-72 h-full overflow-auto shrink-0 p-2 rounded-lg bg-green-500 ${
+          props.sidebarVisible
+            ? `absolute z-40 ${styles.custom_sidebar} lg:static`
+            : "hidden"
+        } lg:block`}
+      >
+        <SideBarButtons disabledSidebarSteps={props.disabledSidebarSteps} />
+      </div>
+    </>
   );
 }
+
+// export default function SideBar(props: SideBarProps) {
+//   return (
+//     <>
+//       {/* <div
+//         className={`h-full w-full left-0 bg-gray-500 z-30 opacity-40 ${
+//           props.sidebarVisible ? "absolute" : "hidden"
+//         }`}
+//         onClick={props.toggleSidebar}
+//       ></div> */}
+//       <div
+//         className={`w-72 h-full overflow-auto shrink-0 p-2 rounded-lg bg-green-500 ${
+//           props.sidebarVisible
+//             ? `absolute z-40 ${styles.custom_sidebar} transition-all`
+//             : `translate-x-[-300px] transition-all`
+//         } lg:block`}
+//       >
+//         <SideBarButtons disabledSidebarSteps={props.disabledSidebarSteps} />
+//       </div>
+//     </>
+//   );
+// }
 
 interface SidebarButtonsProps {
   disabledSidebarSteps: string[];

--- a/frontend/components/top_bar.tsx
+++ b/frontend/components/top_bar.tsx
@@ -3,14 +3,15 @@ import Image from "next/image";
 import BurgerMenuIcon from "./burger_menu/burger_menu_button";
 
 interface TopBarProps {
-  burgerMenuFunction: () => void;
+  sidebarVisible: boolean;
+  toggleSidebar: () => void;
 }
 
-export default function TopBar({ burgerMenuFunction }: TopBarProps) {
+export default function TopBar({ sidebarVisible, toggleSidebar }: TopBarProps) {
   return (
     <div className="bg-green-600 flex justify-between p-2 mt-2 ml-2 mr-2 rounded-lg h-14">
       <div className="lg:hidden">
-        <BurgerMenuIcon onButtonClick={burgerMenuFunction} />
+        <BurgerMenuIcon isBurgerIcon={!sidebarVisible} toggleIcon={toggleSidebar} />
       </div>
       <Link href="/" className="text-white text-2xl font-bold">
         <span className="align-middle">Active Statistics</span>


### PR DESCRIPTION
Fiddling with the side to add some improvements. Here are some things it does now:

1. When left open, and the screen expands, pops back into place.
2. Can be closed by clicking anywhere on the screen that isn't the sidebar on mobile.
3. Burger menu state is always correct. Could be made incorrect when clicking off screen.