### PR TITLE
Redirect to download-strava-data error

### DIFF
--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function Home() {
   const router = useRouter();
-  router.push("/home/download_strava_data");
+
+  useEffect(() => {
+    router.push("/home/download_strava_data");
+  });
 }


### PR DESCRIPTION
Whenever I redirected from /home to /home/download_strava_data, I got a whopping great big error that was stopping me from being able to fix other errors because I didn't know which was which. Using the router in the set state, and not the rendering of the component seems to have fixed it though.