### PR TITLE
/api/data_status: Data Status stop returning true immediately

### DIFF
--- a/backend/backend/utils/dynamodb.py
+++ b/backend/backend/utils/dynamodb.py
@@ -23,6 +23,7 @@ class DownloadStatusItem(BaseModel):
     status: str
     ttl: dt.datetime
     error: bool
+    complete: bool
 
 
 def save_user_data_to_dynamo(
@@ -88,6 +89,7 @@ def save_download_status_to_dynamo(
     download_time: dt.datetime,
     status: str,
     error: bool,
+    complete: bool,
 ) -> None:
     try:
         # Use the attributes from the Pydantic model
@@ -97,13 +99,15 @@ def save_download_status_to_dynamo(
                 "SET last_download_time = :last_download_time, "
                 "status_message = :status_message, "
                 "time_to_live = :time_to_live, "
-                "download_error = :download_error"
+                "download_error = :download_error, "
+                "complete = :complete"
             ),
             ExpressionAttributeValues={
                 ":last_download_time": int(download_time.timestamp()),
                 ":status_message": status,
                 ":time_to_live": int(download_time.timestamp()) + TTL_TIME_IN_FUTURE,
                 ":download_error": error,
+                ":complete": complete,
             },
             ReturnValues="ALL_NEW",
         )
@@ -136,4 +140,5 @@ def get_download_status_item_from_dynamo(
             status=response["Item"]["status_message"],
             ttl=response["Item"]["time_to_live"],
             error=response["Item"]["download_error"],
+            complete=response["Item"]["complete"],
         )

--- a/backend/tests/test_utils/test_dynamodb/test_dynamodb.py
+++ b/backend/tests/test_utils/test_dynamodb/test_dynamodb.py
@@ -92,6 +92,7 @@ def test_save_data_status_to_dynamodb() -> None:
         dt.datetime(2020, 1, 2, tzinfo=dt.timezone.utc),
         "yeet",
         error=False,
+        complete=True,
     )
     request = data_status_table.get_item(Key={"athlete_id": 1})
     assert "Item" in request
@@ -143,6 +144,7 @@ def test_get_last_downloaded_status_item_from_dynamo() -> None:
         dt.datetime(2024, 1, 1, 1, 1, 1, tzinfo=dt.timezone.utc),
         "yeet",
         error=False,
+        complete=True,
     )
     download_status_row = get_download_status_item_from_dynamo(data_status_table, 1)
     assert download_status_row.athlete_id == 1
@@ -153,7 +155,8 @@ def test_get_last_downloaded_status_item_from_dynamo() -> None:
     assert download_status_row.ttl == dt.datetime(
         2024, 1, 1, 1, 1, 1, tzinfo=dt.timezone.utc
     ) + dt.timedelta(days=7)
-    assert download_status_row.error == False
+    assert not download_status_row.error
+    assert download_status_row.complete
 
 
 @mock_aws


### PR DESCRIPTION
If there was any message at all in the data_status dynamo table, as long as it wasn't an error (even if it was just a status message saying that a data download had started) it would let you attempt to look at plots which would obviously error.